### PR TITLE
Add support for annotated method listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,27 @@ public Listener listener1() {
 }
 ```
 
+
+### Creating a Method Listener:
+
+Method Listeners are created by using `@EventHandler` (*not* `@EventListener`) on a function that takes an event and 
+returns `Unit` (or `void` in Java). They can only be registered using `EventBus#subscribe` and *always* require an
+annotation. The listened Event Type is automatically derived from the function signature. As usual, both instance,
+object and (java) static methods are scanned. **Note**: since this internally uses `invokedynamic` and `MethodHandles`,
+greater performance is generally achieved by having these methods `public` instead of `private`.
+
+```kt
+@EventHandler(
+    priority = 0, // Optional
+    receiveCancelled = false, // Optional
+    parallel = false, // Optional
+)
+fun annotatedListener(event: SomeEvent) {
+    /* listener body */
+}
+```
+
+
 #### priority
 
 The priority of this `Listener`. Listeners with a higher priority will receive events before listeners with a lower

--- a/src/test/java/JavaTest.java
+++ b/src/test/java/JavaTest.java
@@ -1,4 +1,6 @@
-import me.bush.eventbuskotlin.Event;import me.bush.eventbuskotlin.EventBus;
+import me.bush.eventbuskotlin.EventBus;
+import me.bush.eventbuskotlin.EventHandler;
+import me.bush.eventbuskotlin.EventListener;
 import me.bush.eventbuskotlin.Listener;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -34,7 +36,7 @@ public class JavaTest {
         eventBus.subscribe(this);
         SimpleEvent event = new SimpleEvent();
         eventBus.post(event);
-        Assertions.assertEquals(event.getCount(), 4);
+        Assertions.assertEquals(8, event.getCount());
     }
 
     public Listener someInstanceListenerField = listener(SimpleEvent.class, event -> {
@@ -56,4 +58,24 @@ public class JavaTest {
             event.setCount(event.getCount() + 1);
         });
     }
- }
+
+    @EventHandler
+    public void someAnnotatedListenerMethod(SimpleEvent event) {
+        event.setCount(event.getCount() + 1);
+    }
+
+    @EventHandler
+    private void somePrivateAnnotatedListenerMethod(SimpleEvent event) {
+        event.setCount(event.getCount() + 1);
+    }
+
+    @EventHandler
+    public static void someStaticAnnotatedListenerMethod(SimpleEvent event) {
+        event.setCount(event.getCount() + 1);
+    }
+
+    @EventHandler
+    private static void someStaticPrivateAnnotatedListenerMethod(SimpleEvent event) {
+        event.setCount(event.getCount() + 1);
+    }
+}

--- a/src/test/kotlin/KotlinTest.kt
+++ b/src/test/kotlin/KotlinTest.kt
@@ -85,7 +85,7 @@ class KotlinTest {
         eventBus.subscribe(ObjectTest)
         val event = SimpleEvent()
         eventBus.post(event)
-        Assertions.assertEquals(3, event.count)
+        Assertions.assertEquals(5, event.count)
         eventBus.unsubscribe(ObjectTest)
     }
 
@@ -271,6 +271,16 @@ class KotlinTest {
 object ObjectTest {
     private val listener1 = listener<SimpleEvent> {
         it.count++
+    }
+
+    @EventHandler
+    fun listenerAnnotated(event: SimpleEvent) {
+        event.count++
+    }
+
+    @EventHandler
+    private fun listenerAnnotatedPrivate(event: SimpleEvent) {
+        event.count++
     }
 
     @EventListener


### PR DESCRIPTION
Adds support to automatically create `Listener`s using MethodHandles or Reflection from methods that take a single event type and an `@EventHandler` annotation.

See the README.md for an example.

@therealbush: The name of `@EventHandler` is still very much up for debate with me, I am not really satisfied with this.